### PR TITLE
[Feat] 뷰페이저 분리 구현 (#29)

### DIFF
--- a/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
+++ b/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		CEF6E04328780EDA00A1636F /* tempFoundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E04228780EDA00A1636F /* tempFoundation.swift */; };
 		CEF6E04528780EE100A1636F /* tempAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E04428780EE100A1636F /* tempAPIService.swift */; };
 		CEF6E04728780EE800A1636F /* tempModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E04628780EE800A1636F /* tempModel.swift */; };
-		CEF6E05428780FAA00A1636F /* tempUIComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E05328780FAA00A1636F /* tempUIComponent.swift */; };
+		CEF6E05428780FAA00A1636F /* CustomViewPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E05328780FAA00A1636F /* CustomViewPager.swift */; };
 		CEF6E07D287814A400A1636F /* tempAuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E07C287814A400A1636F /* tempAuthModel.swift */; };
 		CEF6E07F287814AB00A1636F /* tempAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E07E287814AB00A1636F /* tempAuthView.swift */; };
 		CEF6E081287814AF00A1636F /* tempAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF6E080287814AF00A1636F /* tempAuthController.swift */; };
@@ -70,7 +70,7 @@
 		CEF6E04228780EDA00A1636F /* tempFoundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempFoundation.swift; sourceTree = "<group>"; };
 		CEF6E04428780EE100A1636F /* tempAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempAPIService.swift; sourceTree = "<group>"; };
 		CEF6E04628780EE800A1636F /* tempModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempModel.swift; sourceTree = "<group>"; };
-		CEF6E05328780FAA00A1636F /* tempUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempUIComponent.swift; sourceTree = "<group>"; };
+		CEF6E05328780FAA00A1636F /* CustomViewPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomViewPager.swift; sourceTree = "<group>"; };
 		CEF6E07C287814A400A1636F /* tempAuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempAuthModel.swift; sourceTree = "<group>"; };
 		CEF6E07E287814AB00A1636F /* tempAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempAuthView.swift; sourceTree = "<group>"; };
 		CEF6E080287814AF00A1636F /* tempAuthController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tempAuthController.swift; sourceTree = "<group>"; };
@@ -220,7 +220,7 @@
 		CEF6E04928780F0B00A1636F /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
-				CEF6E05328780FAA00A1636F /* tempUIComponent.swift */,
+				CEF6E05328780FAA00A1636F /* CustomViewPager.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -671,7 +671,7 @@
 				CEF6E04728780EE800A1636F /* tempModel.swift in Sources */,
 				CEF6E095287814DA00A1636F /* tempHaruHappicModel.swift in Sources */,
 				CE380B0C2878A3AF0030D51A /* NSObject+.swift in Sources */,
-				CEF6E05428780FAA00A1636F /* tempUIComponent.swift in Sources */,
+				CEF6E05428780FAA00A1636F /* CustomViewPager.swift in Sources */,
 				CEF6E07D287814A400A1636F /* tempAuthModel.swift in Sources */,
 				CEF6E08B287814C400A1636F /* tempHappicCapsuleView.swift in Sources */,
 				8E9D1643287AD62300269EA2 /* UIColorLiteral.swift in Sources */,

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomViewPager.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomViewPager.swift
@@ -1,0 +1,88 @@
+//
+//  CustomViewPager.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/08.
+//
+
+import UIKit
+import Tabman
+import Pageboy
+import SnapKit
+
+final class CustomViewPager: UIView {
+    // MARK: - Properties
+    var viewControllers: [UIViewController]
+    var buttonTitles: [String]
+    
+    // MARK: - UI
+    private let tabMan = TabmanViewController()
+    
+    // MARK: - View Life Cycle
+    init(viewControllers: [UIViewController],
+         buttonTitles: [String],
+         barHeight: Int = 40,
+         isScrollEnabled: Bool) {
+        self.viewControllers = viewControllers
+        self.buttonTitles = buttonTitles
+        super.init(frame: .zero)
+        configureUI()
+        setViewPager(barHeight: barHeight, isScrollEnabled: isScrollEnabled)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    private func configureUI() {
+        tabMan.view.frame = self.frame
+        addSubview(tabMan.view)
+        tabMan.dataSource = self
+    }
+    
+    private func setViewPager(barHeight: Int, isScrollEnabled: Bool) {
+        // Create bar
+        let bar = TMBar.ButtonBar()
+        bar.layout.transitionStyle = .snap
+        bar.layout.alignment = .centerDistributed
+        bar.layout.contentMode = .fit
+        bar.layout.interButtonSpacing = 0
+        bar.buttons.customize { button in
+            button.backgroundColor = .black
+            button.tintColor = .white
+            button.selectedTintColor = .orange
+            button.heightAnchor.constraint(equalToConstant: CGFloat(barHeight)).isActive = true
+        }
+        
+        bar.indicator.tintColor = .orange
+        bar.indicator.weight = .custom(value: 1)
+        
+        // Add to view
+        tabMan.addBar(bar, dataSource: self, at: .top)
+        tabMan.isScrollEnabled = isScrollEnabled
+    }
+    
+    func scrollToIndex(indexOf: Int) {
+        tabMan.scrollToPage(.at(index: indexOf), animated: false)
+    }
+}
+
+extension CustomViewPager: PageboyViewControllerDataSource, TMBarDataSource {
+    func numberOfViewControllers(in pageboyViewController: PageboyViewController) -> Int {
+        return viewControllers.count
+    }
+    
+    func viewController(for pageboyViewController: PageboyViewController, at index: PageboyViewController.PageIndex) -> UIViewController? {
+        return viewControllers[index]
+    }
+    
+    func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page? {
+        return nil
+    }
+    
+    func barItem(for bar: TMBar, at index: Int) -> TMBarItemable {
+        let item = TMBarItem(title: buttonTitles[index])
+        return item
+    }
+}

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/tempUIComponent.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/tempUIComponent.swift
@@ -1,8 +1,0 @@
-//
-//  temp.swift
-//  Happic-iOS
-//
-//  Created by sejin on 2022/07/08.
-//
-
-import Foundation


### PR DESCRIPTION

## 💥 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- closed: #29 

## 💥 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- CustomViewPager.swift에 Tabman을 사용하여 뷰페이저 분리 구현

## 💥 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- init할 때 viewPager에 들어갈 뷰 컨트롤러 리스트, 각 탭에 들어갈 버튼 title 리스트, 탭바 높이(디폴트 값은 40), isScrollEnabled는 탭바 좌우 스크롤 가능 여부를 입력하여 뷰페이저 생성
- 궁금한 사항은 리뷰로 달아주세요

## 💥 참고 사항

<!-- 참고할 사항(+스크린샷, ToDo)이 있다면 적어주세요. -->
<img src = "https://user-images.githubusercontent.com/77267404/178300123-20232186-052f-43ad-a57e-8a8ea870ff4b.png" width = "300">

뷰페이저 사용 예시 사진입니다. (우리 구현 뷰와는 무관)

