### PR TITLE
[Feat] 전체보기 뷰 기초 UI (#53)

### DIFF
--- a/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
+++ b/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
@@ -73,6 +73,11 @@
 		CEFC3C41287D621B00F187BE /* CategoryDetailWithImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C40287D621B00F187BE /* CategoryDetailWithImageCollectionViewCell.swift */; };
 		CEFC3C44287DCFF600F187BE /* CalendarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C43287DCFF600F187BE /* CalendarHelper.swift */; };
 		CEFC3C46287DF5A000F187BE /* MonthHappicRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C45287DF5A000F187BE /* MonthHappicRecordView.swift */; };
+		CEFC3C49287E945000F187BE /* OverallStatsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C48287E945000F187BE /* OverallStatsController.swift */; };
+		CEFC3C4C287E95F900F187BE /* KeywordRankController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C4B287E95F900F187BE /* KeywordRankController.swift */; };
+		CEFC3C4E287E960800F187BE /* CategoryRankController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C4D287E960800F187BE /* CategoryRankController.swift */; };
+		CEFC3C50287E961200F187BE /* MonthHappicRecordController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C4F287E961200F187BE /* MonthHappicRecordController.swift */; };
+		CEFC3C53287EA88C00F187BE /* CustomTabPagerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFC3C52287EA88C00F187BE /* CustomTabPagerButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -139,6 +144,11 @@
 		CEFC3C40287D621B00F187BE /* CategoryDetailWithImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailWithImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		CEFC3C43287DCFF600F187BE /* CalendarHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHelper.swift; sourceTree = "<group>"; };
 		CEFC3C45287DF5A000F187BE /* MonthHappicRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthHappicRecordView.swift; sourceTree = "<group>"; };
+		CEFC3C48287E945000F187BE /* OverallStatsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverallStatsController.swift; sourceTree = "<group>"; };
+		CEFC3C4B287E95F900F187BE /* KeywordRankController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordRankController.swift; sourceTree = "<group>"; };
+		CEFC3C4D287E960800F187BE /* CategoryRankController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRankController.swift; sourceTree = "<group>"; };
+		CEFC3C4F287E961200F187BE /* MonthHappicRecordController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthHappicRecordController.swift; sourceTree = "<group>"; };
+		CEFC3C52287EA88C00F187BE /* CustomTabPagerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabPagerButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -567,6 +577,7 @@
 			children = (
 				CEF6E0A4287814FC00A1636F /* HappicReportController.swift */,
 				CEFC3C35287D4CA700F187BE /* CategoryDetailController */,
+				CEFC3C47287E90AB00F187BE /* OverallStats */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -574,6 +585,7 @@
 		CEF6E0742878146500A1636F /* View */ = {
 			isa = PBXGroup;
 			children = (
+				CEFC3C51287EA84700F187BE /* CustomTabPagerButton */,
 				CEFC3C2F287D2FBC00F187BE /* SectionHeader */,
 				CEFC3C30287D370D00F187BE /* Cell */,
 				CEF6E0A2287814F600A1636F /* BestHappicMomentView.swift */,
@@ -648,6 +660,33 @@
 				CEFC3C43287DCFF600F187BE /* CalendarHelper.swift */,
 			);
 			path = Util;
+			sourceTree = "<group>";
+		};
+		CEFC3C47287E90AB00F187BE /* OverallStats */ = {
+			isa = PBXGroup;
+			children = (
+				CEFC3C4A287E95BB00F187BE /* StatsController */,
+				CEFC3C48287E945000F187BE /* OverallStatsController.swift */,
+			);
+			path = OverallStats;
+			sourceTree = "<group>";
+		};
+		CEFC3C4A287E95BB00F187BE /* StatsController */ = {
+			isa = PBXGroup;
+			children = (
+				CEFC3C4B287E95F900F187BE /* KeywordRankController.swift */,
+				CEFC3C4D287E960800F187BE /* CategoryRankController.swift */,
+				CEFC3C4F287E961200F187BE /* MonthHappicRecordController.swift */,
+			);
+			path = StatsController;
+			sourceTree = "<group>";
+		};
+		CEFC3C51287EA84700F187BE /* CustomTabPagerButton */ = {
+			isa = PBXGroup;
+			children = (
+				CEFC3C52287EA88C00F187BE /* CustomTabPagerButton.swift */,
+			);
+			path = CustomTabPagerButton;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -769,10 +808,14 @@
 				CEBB69D52873087D000EEB8A /* SceneDelegate.swift in Sources */,
 				CEF6E04328780EDA00A1636F /* tempFoundation.swift in Sources */,
 				CEF6E091287814D100A1636F /* tempHomeView.swift in Sources */,
+				CEFC3C50287E961200F187BE /* MonthHappicRecordController.swift in Sources */,
+				CEFC3C4C287E95F900F187BE /* KeywordRankController.swift in Sources */,
 				CEF6E08D287814C900A1636F /* tempHappicCapsuleController.swift in Sources */,
 				CEF6E083287814B300A1636F /* tempCreateCharacterModel.swift in Sources */,
 				8EB21130287D5A1400F53A95 /* PhotoCollectionViewCell.swift in Sources */,
 				CEF6E0B82878A1C200A1636F /* String+.swift in Sources */,
+				CEFC3C49287E945000F187BE /* OverallStatsController.swift in Sources */,
+				CEFC3C53287EA88C00F187BE /* CustomTabPagerButton.swift in Sources */,
 				CEF6E04528780EE100A1636F /* tempAPIService.swift in Sources */,
 				CEF6E099287814E100A1636F /* HaruHappicController.swift in Sources */,
 				CEF6E093287814D500A1636F /* HomeController.swift in Sources */,
@@ -797,6 +840,7 @@
 				CEF6E0A92878150400A1636F /* tempSettingView.swift in Sources */,
 				CEF6E09F287814ED00A1636F /* CreateContentsController.swift in Sources */,
 				CEF6E081287814AF00A1636F /* tempAuthController.swift in Sources */,
+				CEFC3C4E287E960800F187BE /* CategoryRankController.swift in Sources */,
 				CEF6E09D287814E900A1636F /* tempCreateContentsView.swift in Sources */,
 				CEFC3C41287D621B00F187BE /* CategoryDetailWithImageCollectionViewCell.swift in Sources */,
 				CEFC3C44287DCFF600F187BE /* CalendarHelper.swift in Sources */,

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/CategoryDetailController/CategoryDetailController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/CategoryDetailController/CategoryDetailController.swift
@@ -15,6 +15,7 @@ enum CategoryType {
 }
 
 class CategoryDetailController: UIViewController {
+    
     // MARK: - Properties
     var type: CategoryType = .hourCategory
     

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/CategoryDetailController/CategoryDetailController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/CategoryDetailController/CategoryDetailController.swift
@@ -67,6 +67,10 @@ class CategoryDetailController: UIViewController {
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
+    
+    func collectionViewCanScroll(_ isScrollEnabled: Bool) {
+        rankCollectionView.isScrollEnabled = isScrollEnabled
+    }
 }
 
 // MARK: - Extensions

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -77,6 +77,8 @@ final class HappicReportController: UIViewController {
     }
 }
 
+// MARK: - Extensions
+
 extension HappicReportController: HappicReportSectionHeaderDelegate {
     func showOverallStatsController(type: HappicReportSectionType) {
         let overallStatsController = OverallStatsController()

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -23,15 +23,19 @@ final class HappicReportController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        keywordRankView.headerView.delegate = self
-        categoryRankView.headerView.delegate = self
-        monthHappicRecordView.headerView.delegate = self
+        setDelegate()
     }
     
     // MARK: - Functions
     private func configureUI() {
         setScrollViewLayout()
         setSubViewsLayout()
+    }
+    
+    private func setDelegate() {
+        keywordRankView.headerView.delegate = self
+        categoryRankView.headerView.delegate = self
+        monthHappicRecordView.headerView.delegate = self
     }
     
     private func setScrollViewLayout() {

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -23,6 +23,9 @@ final class HappicReportController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        keywordRankView.headerView.delegate = self
+        categoryRankView.headerView.delegate = self
+        monthHappicRecordView.headerView.delegate = self
     }
     
     // MARK: - Functions
@@ -71,5 +74,13 @@ final class HappicReportController: UIViewController {
             make.height.equalTo(313)
             make.bottom.equalToSuperview().inset(50)
         }
+    }
+}
+
+extension HappicReportController: HappicReportSectionHeaderDelegate {
+    func showOverallStatsController(type: HappicReportSectionType) {
+        let overallStatsController = OverallStatsController()
+        overallStatsController.selectedIndex = type.rawValue
+        self.navigationController?.pushViewController(overallStatsController, animated: true)
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
@@ -1,0 +1,97 @@
+//
+//  OverallStatsController.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/13.
+//
+
+import UIKit
+import Tabman
+import Pageboy
+
+final class OverallStatsController: UIViewController {
+
+    // MARK: - Properties
+    private let viewPager = TabmanViewController()
+    private let keywordRankViewController = KeywordRankController()
+    private let categoryRankController = CategoryRankController()
+    private let monthHappicRecordController = MonthHappicRecordController()
+
+    private lazy var viewControllers = [keywordRankViewController, categoryRankController, monthHappicRecordController]
+    
+    private let buttonTitles = ["키워드 순위", "카테고리 별 순위", "월 기록 횟수"]
+    
+    var selectedIndex = 0
+    
+    // MARK: - UI
+    private lazy var containerView = UIView()
+
+    // MARK: - View Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setViewPager()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        scrollToIndex(indexOf: selectedIndex)
+    }
+    
+    // MARK: - Functions
+    private func setViewPager() {
+        setViewPagerLayout()
+        setViewPagerBar()
+        viewPager.dataSource = self
+    }
+    
+    private func setViewPagerBar() {
+        let bar = TMBarView<TMHorizontalBarLayout, CustomTabPagerButton, TMBarIndicator.None>()
+        bar.layout.transitionStyle = .snap
+        bar.layout.alignment = .centerDistributed
+        bar.layout.contentMode = .fit
+        bar.layout.interButtonSpacing = 0
+        bar.buttons.customize { button in
+            button.font = UIFont.font(.pretendardMedium, ofSize: 12)
+            button.backgroundColor = UIColor.hpGray9
+            button.tintColor = .lightGray
+            button.selectedTintColor = .orange
+            button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        }
+        bar.indicator.isHidden = true
+        viewPager.addBar(bar, dataSource: self, at: .top)
+        viewPager.isScrollEnabled = false
+    }
+
+    private func setViewPagerLayout() {
+        view.addSubview(containerView)
+        containerView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        viewPager.view.frame = containerView.frame
+        containerView.addSubview(viewPager.view)
+    }
+    
+    func scrollToIndex(indexOf: Int) {
+        viewPager.scrollToPage(.at(index: indexOf), animated: false)
+    }
+}
+
+// MARK: - Extensions
+extension OverallStatsController: PageboyViewControllerDataSource, TMBarDataSource {
+    func numberOfViewControllers(in pageboyViewController: PageboyViewController) -> Int {
+        return viewControllers.count
+    }
+
+    func viewController(for pageboyViewController: PageboyViewController, at index: PageboyViewController.PageIndex) -> UIViewController? {
+        return viewControllers[index]
+    }
+
+    func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page? {
+        return nil
+    }
+
+    func barItem(for bar: TMBar, at index: Int) -> TMBarItemable {
+        let item = TMBarItem(title: buttonTitles[index])
+        return item
+    }
+}

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
@@ -16,11 +16,8 @@ final class OverallStatsController: UIViewController {
     private let keywordRankViewController = KeywordRankController()
     private let categoryRankController = CategoryRankController()
     private let monthHappicRecordController = MonthHappicRecordController()
-
     private lazy var viewControllers = [keywordRankViewController, categoryRankController, monthHappicRecordController]
-    
     private let buttonTitles = ["키워드 순위", "카테고리 별 순위", "월 기록 횟수"]
-    
     var selectedIndex = 0
     
     // MARK: - UI

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/OverallStatsController.swift
@@ -33,7 +33,13 @@ final class OverallStatsController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.navigationBar.isHidden = false
+        navigationController?.navigationBar.tintColor = .white
         scrollToIndex(indexOf: selectedIndex)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        self.navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Functions

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -25,7 +25,7 @@ final class CategoryRankController: UIViewController {
         categoryRankView.headerView.hideShowDetailRankViewButton()
         categoryRankView.collectionViewCanScroll(true)
         categoryRankView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-        }
+            make.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -1,0 +1,17 @@
+//
+//  CategoryRankController.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/13.
+//
+
+import UIKit
+
+final class CategoryRankController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .red
+    }
+}

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class CategoryRankController: UIViewController {
+    
     // MARK: - UI
     private lazy var categoryRankView = CategoryRankView()
     

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -8,10 +8,23 @@
 import UIKit
 
 final class CategoryRankController: UIViewController {
-
+    // MARK: - UI
+    private lazy var categoryRankView = CategoryRankView()
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        view.backgroundColor = .red
+        
+        configureUI()
+    }
+    
+    // MARK: - Functions
+    private func configureUI() {
+        view.addSubviews(categoryRankView)
+        categoryRankView.headerView.hideShowDetailRankViewButton()
+        categoryRankView.collectionViewCanScroll(true)
+        categoryRankView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
@@ -8,10 +8,24 @@
 import UIKit
 
 final class KeywordRankController: UIViewController {
-
+    
+    // MARK: - UI
+    private lazy var keywordRankView = KeywordRankView()
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .purple
+        configureUI()
+    }
+    
+    // MARK: - Functions
+    private func configureUI() {
+        view.addSubviews(keywordRankView)
+        keywordRankView.headerView.hideShowDetailRankViewButton()
+        keywordRankView.collectionViewCanScroll(true)
+        keywordRankView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
@@ -1,0 +1,17 @@
+//
+//  KeywordRankController.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/13.
+//
+
+import UIKit
+
+final class KeywordRankController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .purple
+    }
+}

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
@@ -25,7 +25,8 @@ final class KeywordRankController: UIViewController {
         keywordRankView.headerView.hideShowDetailRankViewButton()
         keywordRankView.collectionViewCanScroll(true)
         keywordRankView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
+            make.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -8,10 +8,23 @@
 import UIKit
 
 final class MonthHappicRecordController: UIViewController {
-
+    
+    // MARK: - UI
+    private let monthHappicRecordView = MonthHappicRecordView()
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        view.backgroundColor = .systemPink
+        configureUI()
+    }
+    
+    // MARK: - Functions
+    private func configureUI() {
+        view.addSubviews(monthHappicRecordView)
+        monthHappicRecordView.headerView.hideShowDetailRankViewButton()
+        monthHappicRecordView.snp.makeConstraints { make in
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(295)
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -1,0 +1,17 @@
+//
+//  MonthHappicRecordController.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/13.
+//
+
+import UIKit
+
+final class MonthHappicRecordController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemPink
+    }
+}

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -15,6 +15,7 @@ final class MonthHappicRecordController: UIViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         configureUI()
     }
     

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -24,7 +24,8 @@ final class MonthHappicRecordController: UIViewController {
         view.addSubviews(monthHappicRecordView)
         monthHappicRecordView.headerView.hideShowDetailRankViewButton()
         monthHappicRecordView.snp.makeConstraints { make in
-            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             make.height.equalTo(295)
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CategoryRankView.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CategoryRankView.swift
@@ -16,8 +16,10 @@ final class CategoryRankView: UIView {
     private lazy var whoViewController = CategoryDetailController(type: .whoCategory)
     private lazy var whatViewController = CategoryDetailController(type: .whatCategory)
     
+    private lazy var viewControllers = [hourViewController, whereViewController, whoViewController, whatViewController]
+    
     private lazy var categoryViewPager = CustomViewPager(
-        viewControllers: [hourViewController, whereViewController, whoViewController, whatViewController],
+        viewControllers: viewControllers,
         buttonTitles: ["#hour", "#where", "#who", "#what"], isScrollEnabled: false)
 
     // MARK: - Initialization
@@ -41,6 +43,12 @@ final class CategoryRankView: UIView {
             make.top.equalTo(headerView.snp.bottom)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
+        }
+    }
+    
+    func collectionViewCanScroll(_ isScrollEnabled: Bool) {
+        viewControllers.forEach {
+            $0.collectionViewCanScroll(isScrollEnabled)
         }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CategoryRankView.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CategoryRankView.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-class CategoryRankView: UIView {
+final class CategoryRankView: UIView {
     // MARK: - UI
-    private lazy var headerView = HappicReportSectionHeader(type: .categoryRank)
+    let headerView = HappicReportSectionHeader(type: .categoryRank)
     // ViewPager에 들어갈 카테고리 별 ViewController 처리
     private lazy var hourViewController = CategoryDetailController(type: .hourCategory)
     private lazy var whereViewController = CategoryDetailController(type: .whereCategory)

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CustomTabPagerButton/CustomTabPagerButton.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CustomTabPagerButton/CustomTabPagerButton.swift
@@ -14,7 +14,7 @@ class CustomTabPagerButton: Tabman.TMLabelBarButton {
         case .selected:
             backgroundColor = .black
         default:
-            backgroundColor = UIColor.hpGray9
+            backgroundColor = .hpGray9
         }
         super.update(for: selectionState)
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CustomTabPagerButton/CustomTabPagerButton.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/CustomTabPagerButton/CustomTabPagerButton.swift
@@ -1,0 +1,21 @@
+//
+//  CustomTabPagerButton.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/13.
+//
+
+import UIKit
+import Tabman
+
+class CustomTabPagerButton: Tabman.TMLabelBarButton {
+    override func update(for selectionState: TMBarButton.SelectionState) {
+        switch selectionState {
+        case .selected:
+            backgroundColor = .black
+        default:
+            backgroundColor = UIColor.hpGray9
+        }
+        super.update(for: selectionState)
+    }
+}

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/KeywordRankView.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/KeywordRankView.swift
@@ -56,8 +56,12 @@ final class KeywordRankView: UIView {
         keywordCollectionView.snp.makeConstraints { make in
             make.top.equalTo(headerView.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(268)
+            make.bottom.equalToSuperview()
         }
+    }
+    
+    func collectionViewCanScroll(_ isScrollEnabled: Bool) {
+        keywordCollectionView.isScrollEnabled = isScrollEnabled
     }
 }
 

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/KeywordRankView.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/KeywordRankView.swift
@@ -10,7 +10,7 @@ import UIKit
 final class KeywordRankView: UIView {
 
     // MARK: - UI
-    private let headerView = HappicReportSectionHeader(type: .keywordRank)
+    let headerView = HappicReportSectionHeader(type: .keywordRank)
     private lazy var keywordCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/MonthHappicRecordView.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/MonthHappicRecordView.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-class MonthHappicRecordView: UIView {
+final class MonthHappicRecordView: UIView {
     
     // MARK: - UI
-    private let headerView = HappicReportSectionHeader(type: .monthCount)
+    let headerView = HappicReportSectionHeader(type: .monthCount)
     private lazy var countImageView = UIImageView().then {
         $0.image = UIImage()
         $0.backgroundColor = .purple

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/SectionHeader/HappicReportSectionHeader.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/SectionHeader/HappicReportSectionHeader.swift
@@ -7,13 +7,20 @@
 
 import UIKit
 
-enum HappicReportSectionType {
+enum HappicReportSectionType: Int {
     case keywordRank
     case categoryRank
     case monthCount
 }
 
+protocol HappicReportSectionHeaderDelegate: AnyObject {
+    func showOverallStatsController(type: HappicReportSectionType)
+}
+
 final class HappicReportSectionHeader: UIView {
+    // MARK: - Properties
+    var type: HappicReportSectionType = .keywordRank
+    weak var delegate: HappicReportSectionHeaderDelegate?
 
     // MARK: - UI
     private let sectionDividerImageView = UIImageView().then {
@@ -33,10 +40,12 @@ final class HappicReportSectionHeader: UIView {
     private lazy var showDetailRankViewButton = UIButton(type: .system).then {
         $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         $0.tintColor = .white
+        $0.addTarget(self, action: #selector(showDetailRankViewButtonDidTap), for: .touchUpInside)
     }
     
     // MARK: - Initialization
     init(type: HappicReportSectionType) {
+        self.type = type
         super.init(frame: .zero)
         configureUI(type: type)
     }
@@ -75,5 +84,9 @@ final class HappicReportSectionHeader: UIView {
             make.trailing.equalToSuperview()
             make.centerY.equalTo(sectionTitleLabel)
         }
+    }
+    
+    @objc func showDetailRankViewButtonDidTap() {
+        delegate?.showOverallStatsController(type: type)
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/View/SectionHeader/HappicReportSectionHeader.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/View/SectionHeader/HappicReportSectionHeader.swift
@@ -86,6 +86,10 @@ final class HappicReportSectionHeader: UIView {
         }
     }
     
+    func hideShowDetailRankViewButton() {
+        showDetailRankViewButton.isHidden = true
+    }
+    
     @objc func showDetailRankViewButtonDidTap() {
         delegate?.showOverallStatsController(type: type)
     }


### PR DESCRIPTION
## 💥 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- closed: #53 

## 💥 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- 해픽 레포트에서 랭킹 전체보기 화면으로 넘어가는 기능 구현
- 전체 보기 회면의 기초 UI 구현
- 전체 보기 화면의 하위 뷰들의 기초 UI 구현
- 해픽 레포트의 뷰들과 전체 보기 뷰의 하위 뷰들의 구조가 같기 때문에 재사용하였으며 콜렉션 뷰의 스크롤 가능 여부만 바꿀 수 있도록 구현

## 💥 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 코드를 전반적으로 많이 수정했습니다. 문제가 없는지, 더 좋은 방법이 있는지 확인해보고 남겨주세요~~!!

## 💥 참고 사항

<!-- 참고할 사항(+스크린샷, ToDo)이 있다면 적어주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2022-07-13 at 17 11 04](https://user-images.githubusercontent.com/77267404/178684339-39c1c532-5926-4fac-b866-33d8724e45ec.gif)
