### PR TITLE
[Fix] 월 선택 커스텀 뷰 터치 버그 수정 (#63)

### DIFF
--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -7,15 +7,9 @@
 
 import UIKit
 
-//protocol SendMonthDataDelegate {
-//    func monthData(_data: String)
-//}
-
 class CustomMonthPickerView: UIView {
     
     // MARK: - Properties
-//    var delegate: SendMonthDataDelegate?
-//    var month: String
     
     // MARK: - UI
     private lazy var lastYearSelectorButton = UIButton(type: .system).then {
@@ -167,12 +161,5 @@ class CustomMonthPickerView: UIView {
             make.leading.trailing.equalTo(containerView).inset(10)
             make.height.equalTo(160)
         }
-    }
-
-    private func sendData() {
-        // 달 버튼에 대한 클릭 액션 받으면 딜리게이트로 값 상위 뷰에 넘기기
-        
-//        month = month.split(separator: "월")
-//        delegate?.monthData(_data: month)
     }
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -38,7 +38,7 @@ protocol CustomMonthViewDelegate: AnyObject {
         monthLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
         }
-
+        
         monthSelectorArrowImage.snp.makeConstraints { make in
             make.width.height.equalTo(12)
             make.leading.equalTo(monthLabel.snp.trailing).offset(10)

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -11,8 +11,10 @@ protocol CustomMonthViewDelegate: AnyObject {
     func setMonthPickerView(_ isMonthViewEnabled: Bool)
 }
 
+final class CustomMonthView: UIView {
     
     // MARK: - Properties
+    weak var delegate: CustomMonthViewDelegate?
     var isMonthViewEnabled: Bool = false
     
     // MARK: - UI
@@ -64,8 +66,6 @@ protocol CustomMonthViewDelegate: AnyObject {
             make.top.leading.trailing.bottom.equalToSuperview()
         }
     }
-        customMonthPickerView.isHidden = true
-    }
     
     private func setTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(sender:)))
@@ -78,11 +78,6 @@ protocol CustomMonthViewDelegate: AnyObject {
     
     private func setCustomPickerView() {
         isMonthViewEnabled.toggle()
-        
-        if isMonthViewEnabled == true {
-            customMonthPickerView.isHidden = false
-        } else {
-            customMonthPickerView.isHidden = true
-        }
+        delegate?.setMonthPickerView(isMonthViewEnabled)
     }
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -58,18 +58,12 @@ protocol CustomMonthViewDelegate: AnyObject {
     // MARK: - Functions
     private func configureUI() {
         
-        addSubviews(monthPickerView, customMonthPickerView)
+        addSubviews(monthPickerView)
         
         monthPickerView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalToSuperview()
         }
-        
-        customMonthPickerView.snp.makeConstraints { make in
-            make.top.equalTo(monthPickerView.snp.bottom)
-            make.centerX.equalTo(monthPickerView)
-            make.width.equalTo(335)
-            make.height.equalTo(230)
-        }
+    }
         customMonthPickerView.isHidden = true
     }
     

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-final class CustomMonthView: UIView { // delegate 추가
-//    func monthData(_data: String) {
-//        
-//    }
+protocol CustomMonthViewDelegate: AnyObject {
+    func setMonthPickerView(_ isMonthViewEnabled: Bool)
+}
+
     
     // MARK: - Properties
     var isMonthViewEnabled: Bool = false
@@ -51,7 +51,6 @@ final class CustomMonthView: UIView { // delegate 추가
         super.init(frame: frame)
         configureUI()
         setTapGesture()
-//        delegate?.monthData(_data: <#T##String#>)
     }
     
     required init?(coder: NSCoder) {

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -42,7 +42,7 @@ protocol CustomMonthViewDelegate: AnyObject {
         monthSelectorArrowImage.snp.makeConstraints { make in
             make.width.height.equalTo(12)
             make.leading.equalTo(monthLabel.snp.trailing).offset(10)
-            make.centerY.equalToSuperview()
+            make.centerY.equalTo(monthLabel)
         }
     }
     
@@ -63,8 +63,7 @@ protocol CustomMonthViewDelegate: AnyObject {
         addSubviews(monthPickerView, customMonthPickerView)
         
         monthPickerView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-            make.bottom.equalToSuperview().inset(5)
+            make.top.leading.trailing.bottom.equalToSuperview()
         }
         
         customMonthPickerView.snp.makeConstraints { make in

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -16,8 +16,6 @@ protocol CustomMonthViewDelegate: AnyObject {
     var isMonthViewEnabled: Bool = false
     
     // MARK: - UI
-    private lazy var customMonthPickerView = CustomMonthPickerView()
-    
     private lazy var monthLabel = UILabel().then {
         $0.text = "2022 . 06"
         $0.textColor = .hpWhite

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -77,7 +77,6 @@ protocol CustomMonthViewDelegate: AnyObject {
     }
     
     private func setCustomPickerView() {
-        
         isMonthViewEnabled.toggle()
         
         if isMonthViewEnabled == true {

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -33,7 +33,7 @@ final class HaruHappicPhotoController: UIViewController {
     // MARK: - Functions
     private func configureUI() {
         
-        view.addSubviews(containerCollectionView, customMonthView)
+        view.addSubviews(containerCollectionView, customMonthView, customMonthPickerView)
                 
         customMonthView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(30)
@@ -46,7 +46,12 @@ final class HaruHappicPhotoController: UIViewController {
             make.leading.trailing.equalToSuperview().inset(10)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
-    }
+        
+        customMonthPickerView.snp.makeConstraints { make in
+            make.top.equalTo(customMonthView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(10)
+            make.height.equalTo(230)
+        }
     
     private func setCollectionView() {
         containerCollectionView.delegate = self

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -11,7 +11,7 @@ final class HaruHappicPhotoController: UIViewController {
     
     // MARK: - UI
     private lazy var customMonthView = CustomMonthView()
-    
+    private lazy var customMonthPickerView = CustomMonthPickerView()
     private lazy var containerCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -27,6 +27,7 @@ final class HaruHappicPhotoController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        setDelegate()
         setCollectionView()
     }
     
@@ -52,6 +53,12 @@ final class HaruHappicPhotoController: UIViewController {
             make.leading.trailing.equalToSuperview().inset(10)
             make.height.equalTo(230)
         }
+        customMonthPickerView.isHidden = true
+    }
+    
+    private func setDelegate() {
+        customMonthView.delegate = self
+    }
     
     private func setCollectionView() {
         containerCollectionView.delegate = self
@@ -84,5 +91,15 @@ extension HaruHappicPhotoController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 2
+    }
+}
+
+extension HaruHappicPhotoController: CustomMonthViewDelegate {
+    func setMonthPickerView(_ isMonthViewEnabled: Bool) {
+        if isMonthViewEnabled == true {
+            customMonthPickerView.isHidden = false
+        } else {
+            customMonthPickerView.isHidden = true
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -34,7 +34,7 @@ final class HaruHappicPhotoController: UIViewController {
     private func configureUI() {
         
         view.addSubviews(containerCollectionView, customMonthView, customMonthPickerView)
-                
+        
         customMonthView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(30)
             make.leading.trailing.equalToSuperview().inset(100)

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -73,7 +73,7 @@ extension HaruHappicTagViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: collectionView.frame.width, height: 75)
     }
-
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 20
     }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class HaruHappicTagViewController: UIViewController {
-
+    
     // MARK: - UI
     private lazy var customMonthView = CustomMonthView()
 

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -27,6 +27,7 @@ final class HaruHappicTagViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        setDelegate()
         setCollectionView()
     }
     
@@ -53,6 +54,12 @@ final class HaruHappicTagViewController: UIViewController {
             make.leading.trailing.equalToSuperview().inset(10)
             make.height.equalTo(230)
         }
+        customMonthPickerView.isHidden = true
+    }
+    
+    private func setDelegate() {
+        customMonthView.delegate = self
+    }
     
     private func setCollectionView() {
         containerCollectionView.delegate = self
@@ -81,5 +88,15 @@ extension HaruHappicTagViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 20
+    }
+}
+
+extension HaruHappicTagViewController: CustomMonthViewDelegate {
+    func setMonthPickerView(_ isMonthViewEnabled: Bool) {
+        if isMonthViewEnabled == true {
+            customMonthPickerView.isHidden = false
+        } else {
+            customMonthPickerView.isHidden = true
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -11,7 +11,7 @@ final class HaruHappicTagViewController: UIViewController {
     
     // MARK: - UI
     private lazy var customMonthView = CustomMonthView()
-
+    private lazy var customMonthPickerView = CustomMonthPickerView()
     private lazy var containerCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -33,7 +33,7 @@ final class HaruHappicTagViewController: UIViewController {
     // MARK: - Functions
     private func configureUI() {
         
-        view.addSubviews(containerCollectionView, customMonthView)
+        view.addSubviews(containerCollectionView, customMonthView, customMonthPickerView)
         
         customMonthView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(30)
@@ -47,7 +47,12 @@ final class HaruHappicTagViewController: UIViewController {
             make.leading.trailing.equalToSuperview().inset(10)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
-    }
+        
+        customMonthPickerView.snp.makeConstraints { make in
+            make.top.equalTo(customMonthView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(10)
+            make.height.equalTo(230)
+        }
     
     private func setCollectionView() {
         containerCollectionView.delegate = self


### PR DESCRIPTION
## 💥 관련 이슈

- closed: #63

## 💥 구현/변경 사항 및 이유

기존 CustomMonthView에서 불러오던 customMonthPickerView.isHidden 관련 코드를 상위 뷰인 HaruHappicPhotoController과 HaruHappicTagViewController에서 CustomMonthPickerView을 선언하여 해당 영역을 잡아주고 delegate를 사용하여 MonthView를 클릭 시에 MonthPickerView에 isMonthViewEnabled 파라미터를 사용하여 접근하였습니다.

## 💥 참고 사항

![Simulator Screen Recording - iPhone 13 mini - 2022-07-14 at 18 55 03](https://user-images.githubusercontent.com/80062632/178956302-7a00ab04-e01d-47b5-a41d-07f242f63899.gif)

