### PR TITLE
[Feat] 월 선택 커스텀 뷰 UI 마무리 (#66)

### DIFF
--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+// MARK: - Protocols
 protocol CustomMonthPickerViewDelegate: AnyObject {
     func changeMonthStatus(_ month: String)
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -149,6 +149,12 @@ class CustomMonthPickerView: UIView {
             stack.distribution = .fillEqually
         }
         
+        [janButton, febButton, marButton, aprButton,
+         mayButton, junButton, julButton, augButton,
+         sepButton, octButton, novButton, decButton].forEach {
+            $0.addTarget(self, action: #selector(monthButtonDidTap(sender: )), for: .touchUpInside)
+        }
+        
         let containerStack = UIStackView(arrangedSubviews: [stack1, stack2, stack3])
         
         addSubview(containerStack)
@@ -161,5 +167,9 @@ class CustomMonthPickerView: UIView {
             make.leading.trailing.equalTo(containerView).inset(10)
             make.height.equalTo(160)
         }
+    }
+    
+    @objc private func monthButtonDidTap(sender: UIButton) {
+        print(sender.currentTitle)
     }
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol CustomMonthPickerViewDelegate: AnyObject {
+    func changeMonthStatus(_ month: String)
+}
+
 class CustomMonthPickerView: UIView {
     
     // MARK: - Properties
+    weak var delegate: CustomMonthPickerViewDelegate?
     
     // MARK: - UI
     private lazy var lastYearSelectorButton = UIButton(type: .system).then {
@@ -171,6 +176,9 @@ class CustomMonthPickerView: UIView {
     }
     
     @objc private func monthButtonDidTap(sender: UIButton) {
-        print(sender.currentTitle)
+        let month = sender.currentTitle
+        if let month = month?.components(separatedBy: "월") {
+            delegate?.changeMonthStatus(month[0])
+        }
     }
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -176,12 +176,14 @@ final class CustomMonthPickerView: UIView {
         [janButton, febButton, marButton, aprButton,
          mayButton, junButton, julButton, augButton,
          sepButton, octButton, novButton, decButton].forEach {
-            let month = $0.currentAttributedTitle?.string.components(separatedBy: "월") // 버튼 월 : string 타입
-            if currentMonth < Int(month![0])! {
-                $0.setAttributedTitle(NSAttributedString(string: "\(month![0])월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray7]), for: .normal)
+            let monthStr = $0.currentAttributedTitle?.string.components(separatedBy: "월") // 버튼 월 : string 타입
+            guard let month = monthStr?[0],
+                  let selectedMonth = Int(month) else { return }
+            if currentMonth < selectedMonth {
+                $0.setAttributedTitle(NSAttributedString(string: "\(selectedMonth)월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray7]), for: .normal)
                 $0.isEnabled = false
-            } else if currentMonth == Int(month![0])! {
-                $0.setAttributedTitle(NSAttributedString(string: "\(month![0])월", attributes: [.font: UIFont.font(.pretendardBold, ofSize: 16), .foregroundColor: UIColor.hpDarkPurple]), for: .normal)
+            } else if currentMonth == selectedMonth {
+                $0.setAttributedTitle(NSAttributedString(string: "\(selectedMonth)월", attributes: [.font: UIFont.font(.pretendardBold, ofSize: 16), .foregroundColor: UIColor.hpDarkPurple]), for: .normal)
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -12,7 +12,7 @@ protocol CustomMonthPickerViewDelegate: AnyObject {
     func changeMonthStatus(_ month: String)
 }
 
-class CustomMonthPickerView: UIView {
+final class CustomMonthPickerView: UIView {
     
     // MARK: - Properties
     weak var delegate: CustomMonthPickerViewDelegate?

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -112,6 +112,7 @@ class CustomMonthPickerView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
+        controlMonthStatus()
     }
     
     required init?(coder: NSCoder) {
@@ -166,6 +167,21 @@ class CustomMonthPickerView: UIView {
         let month = sender.currentAttributedTitle?.string
         if let month = month?.components(separatedBy: "월") {
             delegate?.changeMonthStatus(month[0])
+        }
+    }
+    
+    private func controlMonthStatus() {
+        let currentMonth = Calendar.current.component(.month, from: Date()) // 현재 월 : int 타입
+        [janButton, febButton, marButton, aprButton,
+         mayButton, junButton, julButton, augButton,
+         sepButton, octButton, novButton, decButton].forEach {
+            let month = $0.currentAttributedTitle?.string.components(separatedBy: "월") // 버튼 월 : string 타입
+            if currentMonth < Int(month![0])! {
+                $0.setAttributedTitle(NSAttributedString(string: "\(month![0])월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray7]), for: .normal)
+                $0.isEnabled = false
+            } else if currentMonth == Int(month![0])! {
+                $0.setAttributedTitle(NSAttributedString(string: "\(month![0])월", attributes: [.font: UIFont.font(.pretendardBold, ofSize: 16), .foregroundColor: UIColor.hpDarkPurple]), for: .normal)
+            }
         }
     }
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -146,6 +146,7 @@ class CustomMonthPickerView: UIView {
         
         for stack in stacks {
             stack.spacing = 20
+            stack.axis = .horizontal
             stack.distribution = .fillEqually
         }
         

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -60,7 +60,6 @@ class CustomMonthPickerView: UIView {
         }
     }
     
-    // 버튼 addtarget 추가하기
     private lazy var janButton = UIButton(type: .system).then {
         $0.setTitle("1월", for: .normal)
         $0.tintColor = .hpGray2

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -43,9 +43,9 @@ class CustomMonthPickerView: UIView {
         $0.addSubviews(lastYearSelectorButton, yearIndicatorLabel, nextYearSelectorButton)
         
         lastYearSelectorButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(34)
-            make.top.equalToSuperview().offset(10)
-            make.width.height.equalTo(48)
+            make.leading.equalToSuperview().offset(30)
+            make.top.equalToSuperview().offset(24)
+            make.width.height.equalTo(20)
         }
         
         yearIndicatorLabel.snp.makeConstraints { make in
@@ -54,8 +54,8 @@ class CustomMonthPickerView: UIView {
         }
         
         nextYearSelectorButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(34)
-            make.width.height.equalTo(48)
+            make.trailing.equalToSuperview().inset(30)
+            make.width.height.equalTo(20)
             make.centerY.equalTo(lastYearSelectorButton)
         }
     }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -30,7 +30,7 @@ class CustomMonthPickerView: UIView {
     private lazy var yearIndicatorLabel = UILabel().then {
         $0.text = "2022"
         $0.textColor = .hpGray4
-        $0.font = UIFont.font(.pretendardBold, ofSize: 16)
+        $0.font = UIFont.font(.gmarketSansBold, ofSize: 16)
     }
     
     private lazy var containerView = UIView().then {
@@ -61,63 +61,51 @@ class CustomMonthPickerView: UIView {
     }
     
     private lazy var janButton = UIButton(type: .system).then {
-        $0.setTitle("1월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "1월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var febButton = UIButton(type: .system).then {
-        $0.setTitle("2월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "2월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var marButton = UIButton(type: .system).then {
-        $0.setTitle("3월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "3월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var aprButton = UIButton(type: .system).then {
-        $0.setTitle("4월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "4월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var mayButton = UIButton(type: .system).then {
-        $0.setTitle("5월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "5월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var junButton = UIButton(type: .system).then {
-        $0.setTitle("6월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "6월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var julButton = UIButton(type: .system).then {
-        $0.setTitle("7월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "7월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var augButton = UIButton(type: .system).then {
-        $0.setTitle("8월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "8월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var sepButton = UIButton(type: .system).then {
-        $0.setTitle("9월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "9월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var octButton = UIButton(type: .system).then {
-        $0.setTitle("10월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "10월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var novButton = UIButton(type: .system).then {
-        $0.setTitle("11월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "11월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     private lazy var decButton = UIButton(type: .system).then {
-        $0.setTitle("12월", for: .normal)
-        $0.tintColor = .hpGray2
+        $0.setAttributedTitle(NSAttributedString(string: "12월", attributes: [.font: UIFont.font(.pretendardMedium, ofSize: 16), .foregroundColor: UIColor.hpGray2]), for: .normal)
     }
     
     // MARK: - Initialization
@@ -175,7 +163,7 @@ class CustomMonthPickerView: UIView {
     }
     
     @objc private func monthButtonDidTap(sender: UIButton) {
-        let month = sender.currentTitle
+        let month = sender.currentAttributedTitle?.string
         if let month = month?.components(separatedBy: "월") {
             delegate?.changeMonthStatus(month[0])
         }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -34,7 +34,10 @@ class CustomMonthPickerView: UIView {
     }
     
     private lazy var containerView = UIView().then {
-        $0.backgroundColor = .hpBgBlack2h // 알파값주기 0.95
+        
+        $0.backgroundColor = .hpBgBlack2h.withAlphaComponent(0.95)
+        $0.layer.borderColor = UIColor.hpDarkPurple.cgColor
+        $0.layer.borderWidth = 1
         $0.layer.cornerRadius = 8
         
         $0.addSubviews(lastYearSelectorButton, yearIndicatorLabel, nextYearSelectorButton)
@@ -131,13 +134,10 @@ class CustomMonthPickerView: UIView {
     // MARK: - Functions
     private func configureUI() {
         
-        backgroundColor = .hpDarkPurple
-        layer.cornerRadius = 8
-        
         addSubview(containerView)
         
         containerView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(1)
+            make.edges.equalToSuperview()
         }
         
         setMonthButtonStack()

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthPickerView.swift
@@ -172,11 +172,11 @@ final class CustomMonthPickerView: UIView {
     }
     
     private func controlMonthStatus() {
-        let currentMonth = Calendar.current.component(.month, from: Date()) // 현재 월 : int 타입
+        let currentMonth = Calendar.current.component(.month, from: Date())
         [janButton, febButton, marButton, aprButton,
          mayButton, junButton, julButton, augButton,
          sepButton, octButton, novButton, decButton].forEach {
-            let monthStr = $0.currentAttributedTitle?.string.components(separatedBy: "월") // 버튼 월 : string 타입
+            let monthStr = $0.currentAttributedTitle?.string.components(separatedBy: "월")
             guard let month = monthStr?[0],
                   let selectedMonth = Int(month) else { return }
             if currentMonth < selectedMonth {

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -18,7 +18,7 @@ final class CustomMonthView: UIView {
     var isMonthViewEnabled: Bool = false
     
     // MARK: - UI
-    private lazy var monthLabel = UILabel().then {
+    lazy var monthLabel = UILabel().then {
         $0.text = "2022 . 06"
         $0.textColor = .hpWhite
         $0.font = UIFont.font(.gmarketSansBold, ofSize: 16)

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+// MARK: - Protocols
 protocol CustomMonthViewDelegate: AnyObject {
     func setMonthPickerView(_ isMonthViewEnabled: Bool)
 }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomRecommendTagView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomRecommendTagView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CustomRecommendTagView: UIView {
+final class CustomRecommendTagView: UIView {
     
     // MARK: - UI
     private lazy var tagLabel = UILabel().then {

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomRecommendTagView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomRecommendTagView.swift
@@ -47,7 +47,6 @@ class CustomRecommendTagView: UIView {
         
         userTextField.snp.makeConstraints { make in
             make.leading.equalTo(verticalLine.snp.trailing).offset(16)
-            //            make.height.equalTo(24)
             make.centerY.equalToSuperview()
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -105,7 +105,6 @@ extension HaruHappicPhotoController: CustomMonthViewDelegate {
     }
 }
 
-
 extension HaruHappicPhotoController: CustomMonthPickerViewDelegate {
     func changeMonthStatus(_ month: String) {
         if month.count == 1 {

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -58,6 +58,7 @@ final class HaruHappicPhotoController: UIViewController {
     
     private func setDelegate() {
         customMonthView.delegate = self
+        customMonthPickerView.delegate = self
     }
     
     private func setCollectionView() {
@@ -100,6 +101,17 @@ extension HaruHappicPhotoController: CustomMonthViewDelegate {
             customMonthPickerView.isHidden = false
         } else {
             customMonthPickerView.isHidden = true
+        }
+    }
+}
+
+
+extension HaruHappicPhotoController: CustomMonthPickerViewDelegate {
+    func changeMonthStatus(_ month: String) {
+        if month.count == 1 {
+            customMonthView.monthLabel.text = "2022 . 0\(month)"
+        } else {
+            customMonthView.monthLabel.text = "2022 . \(month)"
         }
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagViewController.swift
@@ -59,6 +59,7 @@ final class HaruHappicTagViewController: UIViewController {
     
     private func setDelegate() {
         customMonthView.delegate = self
+        customMonthPickerView.delegate = self
     }
     
     private func setCollectionView() {
@@ -97,6 +98,16 @@ extension HaruHappicTagViewController: CustomMonthViewDelegate {
             customMonthPickerView.isHidden = false
         } else {
             customMonthPickerView.isHidden = true
+        }
+    }
+}
+
+extension HaruHappicTagViewController: CustomMonthPickerViewDelegate {
+    func changeMonthStatus(_ month: String) {
+        if month.count == 1 {
+            customMonthView.monthLabel.text = "2022 . 0\(month)"
+        } else {
+            customMonthView.monthLabel.text = "2022 . \(month)"
         }
     }
 }


### PR DESCRIPTION
## 💥 관련 이슈

- closed: #66 

## 💥 구현/변경 사항 및 이유

- custom month picker view 월 별 addtarget 액션 추가 및 배경 색 지정
- delegate 사용하여 선택한 월 상위 뷰로 넘겨주기
- 현재 월에 따라 컬러 작업 및 버튼 활성/비활성화 작업

## 💥 PR Point

- 강제언래핑 해놓은 코드 수정 필요

## 💥 참고 사항

`iPhone 13 mini`

![Simulator Screen Recording - iPhone 13 mini - 2022-07-17 at 02 52 52](https://user-images.githubusercontent.com/80062632/179367156-5ca4bf6f-6e87-4927-8c26-ba4292143188.gif)
