### PR TITLE
[Feat] 소셜 로그인 토큰 UserDefault에 저장 및 기타 수정 (#203)

### DIFF
--- a/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
+++ b/Happic-iOS/Happic-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		CE479652288489F60095ADD4 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE479651288489F60095ADD4 /* NetworkResult.swift */; };
 		CE47965428848A450095ADD4 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE47965328848A450095ADD4 /* BaseResponse.swift */; };
 		CE47965628848B4F0095ADD4 /* NetworkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE47965528848B4F0095ADD4 /* NetworkHelper.swift */; };
+		CE8EDD202890481B009A652A /* UserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8EDD1F2890481B009A652A /* UserDefaultWrapper.swift */; };
+		CE8EDD2228904CB6009A652A /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8EDD2128904CB6009A652A /* UserManager.swift */; };
 		CEA4028628807004009D98EF /* SettingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA4028528807004009D98EF /* SettingCollectionViewCell.swift */; };
 		CEA40289288074FE009D98EF /* SettingSectionHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA40288288074FE009D98EF /* SettingSectionHeaderCollectionReusableView.swift */; };
 		CEA4028B2880799B009D98EF /* CustomPopUpController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA4028A2880799B009D98EF /* CustomPopUpController.swift */; };
@@ -180,6 +182,8 @@
 		CE479651288489F60095ADD4 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		CE47965328848A450095ADD4 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
 		CE47965528848B4F0095ADD4 /* NetworkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHelper.swift; sourceTree = "<group>"; };
+		CE8EDD1F2890481B009A652A /* UserDefaultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultWrapper.swift; sourceTree = "<group>"; };
+		CE8EDD2128904CB6009A652A /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		CEA4028528807004009D98EF /* SettingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCollectionViewCell.swift; sourceTree = "<group>"; };
 		CEA40288288074FE009D98EF /* SettingSectionHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
 		CEA4028A2880799B009D98EF /* CustomPopUpController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPopUpController.swift; sourceTree = "<group>"; };
@@ -926,6 +930,8 @@
 			isa = PBXGroup;
 			children = (
 				CEFC3C43287DCFF600F187BE /* CalendarHelper.swift */,
+				CE8EDD1F2890481B009A652A /* UserDefaultWrapper.swift */,
+				CE8EDD2128904CB6009A652A /* UserManager.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1084,6 +1090,7 @@
 				CEBB69D72873087D000EEB8A /* TabBarController.swift in Sources */,
 				CEBB69D32873087D000EEB8A /* AppDelegate.swift in Sources */,
 				CEF6E0B42878A08400A1636F /* UITextField+.swift in Sources */,
+				CE8EDD2228904CB6009A652A /* UserManager.swift in Sources */,
 				8EC8748A28888E2100974ACE /* PushUserRegisterService.swift in Sources */,
 				CECD7F40288886AB00FD1420 /* KeywordRankModel.swift in Sources */,
 				CECD7F3C28887F5B00FD1420 /* HappicReportSummaryModel.swift in Sources */,
@@ -1105,6 +1112,7 @@
 				8ECAD2BB28894D9700B2CEF0 /* CreateContentsService.swift in Sources */,
 				6BB88529288B096900832D00 /* SignUpService.swift in Sources */,
 				CEF6E0B82878A1C200A1636F /* String+.swift in Sources */,
+				CE8EDD202890481B009A652A /* UserDefaultWrapper.swift in Sources */,
 				CEFC3C49287E945000F187BE /* OverallStatsController.swift in Sources */,
 				CEFC3C53287EA88C00F187BE /* CustomTabPagerButton.swift in Sources */,
 				6BB88523288ADD2100832D00 /* HomeService.swift in Sources */,

--- a/Happic-iOS/Happic-iOS/Global/Supports/AppDelegate.swift
+++ b/Happic-iOS/Happic-iOS/Global/Supports/AppDelegate.swift
@@ -12,6 +12,7 @@ import FirebaseCore
 import Firebase
 import FirebaseMessaging
 import UserNotifications
+import KakaoSDKUser
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -63,6 +64,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         application.registerForRemoteNotifications()
+        
+        let userManager = UserManager.shared
+        if userManager.hasJwtToken {
+            UserApi.shared.accessTokenInfo { data, error in
+                if let error = error {
+                    if let sdkError = error as? SdkError,
+                       sdkError.isInvalidTokenError() == true {
+                        userManager.setLoginStatus(isLoginned: false)
+                    }
+                } else {
+                    // 토큰 유효성이 확인된 경우
+                    userManager.setLoginStatus(isLoginned: true)
+                }
+            } 
+        } else {
+            //유효한 토큰이 없는 경우
+            userManager.setLoginStatus(isLoginned: false)
+        }
         
         return true
     }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
@@ -127,6 +127,11 @@ class CustomPopUpController: UIViewController {
     func setConfirmButtonAction() {
         if popUpTitleLabel.text == "캐릭터 변경 주의사항" {
             print("캐릭터 변경")
+            let createCharacterView = CreateCharacterViewController.instantiate()
+            createCharacterView.isSignUp = false
+            let nav = UINavigationController(rootViewController: createCharacterView)
+            nav.modalPresentationStyle = .fullScreen
+            present(nav, animated: true)
         } else {
             print("삭제하기")
             deleteContents()

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+// MARK: - Protocols
 protocol CustomPopUpControllerDelegate: AnyObject {
     func popUpDidDismiss()
 }
@@ -134,9 +135,9 @@ class CustomPopUpController: UIViewController {
             print("캐릭터 변경")
             let createCharacterView = CreateCharacterViewController.instantiate()
             createCharacterView.isSignUp = false
-            let nav = UINavigationController(rootViewController: createCharacterView)
-            nav.modalPresentationStyle = .fullScreen
-            present(nav, animated: true)
+            let navicationController = UINavigationController(rootViewController: createCharacterView)
+            navicationController.modalPresentationStyle = .fullScreen
+            present(navicationController, animated: true)
         } else {
             print("삭제하기")
             deleteContents()

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol CustomPopUpControllerDelegate: AnyObject {
+    func popUpDidDismiss()
+}
+
 class CustomPopUpController: UIViewController {
     
     // MARK: - Properties
+    weak var delegate: CustomPopUpControllerDelegate?
     var id: String = ""
 
     // MARK: - UI
@@ -146,9 +151,8 @@ extension CustomPopUpController {
             switch response {
             case .success:
                 self.dismiss(animated: true) {
-                    self.tabBarController?.selectedIndex = 1
+                    self.delegate?.popUpDidDismiss()
                 }
-                self.showToast(message: "게시글이 삭제되었습니다.")
             default:
                 break
             }

--- a/Happic-iOS/Happic-iOS/Global/Util/UserDefaultWrapper.swift
+++ b/Happic-iOS/Happic-iOS/Global/Util/UserDefaultWrapper.swift
@@ -15,8 +15,9 @@ import Foundation
         }
         
         set {
-            if newValue == nil { UserDefaults.standard.removeObject(forKey: key) }
-            else { UserDefaults.standard.setValue(newValue, forKey: key) }
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else { UserDefaults.standard.setValue(newValue, forKey: key) }
         }
     }
     

--- a/Happic-iOS/Happic-iOS/Global/Util/UserDefaultWrapper.swift
+++ b/Happic-iOS/Happic-iOS/Global/Util/UserDefaultWrapper.swift
@@ -1,0 +1,28 @@
+//
+//  UserDefaultWrapper.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/27.
+//
+
+import Foundation
+
+@propertyWrapper struct UserDefaultWrapper<T> {
+    
+    var wrappedValue: T? {
+        get {
+            return UserDefaults.standard.object(forKey: self.key) as? T
+        }
+        
+        set {
+            if newValue == nil { UserDefaults.standard.removeObject(forKey: key) }
+            else { UserDefaults.standard.setValue(newValue, forKey: key) }
+        }
+    }
+    
+    private let key: String
+    
+    init(key: String) {
+        self.key = key
+    }
+}

--- a/Happic-iOS/Happic-iOS/Global/Util/UserManager.swift
+++ b/Happic-iOS/Happic-iOS/Global/Util/UserManager.swift
@@ -1,0 +1,33 @@
+//
+//  UserManager.swift
+//  Happic-iOS
+//
+//  Created by sejin on 2022/07/27.
+//
+
+import Foundation
+
+final class UserManager {
+    
+    // MARK: - Properties
+    
+    static let shared = UserManager()
+    private(set) var currentLoginStatus: Bool?
+    
+    @UserDefaultWrapper<String>(key: "jwtToken") private(set) var jwtToken
+    
+    var hasJwtToken: Bool { return self.jwtToken != nil }
+
+    var isLogin: Bool { return self.currentLoginStatus ?? false }
+    var getJwtToken: String { return self.jwtToken ?? "" }
+
+    // MARK: - Life Cycles
+    
+    private init() {}
+    
+    // MARK: - Fuctions
+    
+    func setSocialToken(token: String) {
+        self.jwtToken = token
+    }
+}

--- a/Happic-iOS/Happic-iOS/Global/Util/UserManager.swift
+++ b/Happic-iOS/Happic-iOS/Global/Util/UserManager.swift
@@ -30,4 +30,8 @@ final class UserManager {
     func setSocialToken(token: String) {
         self.jwtToken = token
     }
+    
+    func setLoginStatus(isLoginned: Bool) {
+        self.currentLoginStatus = isLoginned
+    }
 }

--- a/Happic-iOS/Happic-iOS/Network/APIService/AuthService/SignUpService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/AuthService/SignUpService.swift
@@ -44,7 +44,7 @@ struct SignUpService {
                          completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.characterChangeURL
         let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
-        let parameters: Parameters = ["year": characterId, "characterName": characterName]
+        let parameters: Parameters = ["characterId": characterId, "characterName": characterName]
         
         let dataRequest = AF.request(url, method: .patch, parameters: parameters, encoding: JSONEncoding.default, headers: header)
         

--- a/Happic-iOS/Happic-iOS/Network/APIService/AuthService/SignUpService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/AuthService/SignUpService.swift
@@ -10,7 +10,8 @@ import Alamofire
 
 struct SignUpService {
     static let shared = SignUpService()
-    
+    private let userManager = UserManager.shared
+
     private init() {}
     
     func signUp(social: String, characterId: Int, characterName: String, accessToken: String, completion: @escaping (NetworkResult<Any>) -> Void) {
@@ -42,7 +43,7 @@ struct SignUpService {
     func changeCharacter(characterId: Int, characterName: String,
                          completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.characterChangeURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = ["year": characterId, "characterName": characterName]
         
         let dataRequest = AF.request(url, method: .patch, parameters: parameters, encoding: JSONEncoding.default, headers: header)

--- a/Happic-iOS/Happic-iOS/Network/APIService/CreateContentsService/CreateContentsService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/CreateContentsService/CreateContentsService.swift
@@ -10,13 +10,14 @@ import Alamofire
 
 struct CreateContentsService {
     static let shared = CreateContentsService()
+    private let userManager = UserManager.shared
     
     private init() {}
     
     /// 오늘 하루해픽 게시글 작성 여부 조회
     func getPostStatus(completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.isPostedURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         
         let dataRequest = AF.request(url, method: .get, encoding: URLEncoding.default, headers: header)
         
@@ -58,7 +59,7 @@ struct CreateContentsService {
     /// 게시글 작성 시 최다 태그 추천
     func getRecommendTag(completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.recommendTagURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         
         let dataRequest = AF.request(url, method: .get, encoding: URLEncoding.default, headers: header)
         
@@ -78,7 +79,7 @@ struct CreateContentsService {
     /// 하루해픽 게시글 생성
     func createHaruHappic(photo: String, when: Int, place: String, who: String, what: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.createContentsURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let body: Parameters = ["photo": photo,
                                 "when": when,
                                 "where": place,
@@ -103,7 +104,7 @@ struct CreateContentsService {
     /// 하루해픽 게시글 삭제
     func deleteHaruHappic(filmId: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.deleteContentsURL + filmId
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let dataRequest = AF.request(url, method: .delete, encoding: URLEncoding.default, headers: header)
         dataRequest.responseData { response in
             switch response.result {

--- a/Happic-iOS/Happic-iOS/Network/APIService/HappicReportService/HappicReportService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/HappicReportService/HappicReportService.swift
@@ -10,13 +10,14 @@ import Alamofire
 
 struct HappicReportService {
     static let shared = HappicReportService()
+    private let userManager = UserManager.shared
     
     private init() {}
     
     /// 해픽 레포트 조회
     func getHappicReportSummary(year: String, month: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.happicReportSummaryURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = [
             "year": year,
             "month": month
@@ -40,7 +41,7 @@ struct HappicReportService {
     /// 해픽 레포트 키워드 전체 순위 조회
     func getKeywordRank(year: String, month: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.happicReportKeywordRankURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = ["year": year, "month": month]
         let dataRequest = AF.request(url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: header)
         
@@ -61,7 +62,7 @@ struct HappicReportService {
     func getCategoryRank(option: String, year: String, month: String,
                          completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.happicReportCategoryRankURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = ["option": option, "year": year, "month": month]
         
         let dataRequest = AF.request(url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: header)
@@ -82,7 +83,7 @@ struct HappicReportService {
     /// 월별 하루 해픽 조회
     func getMonthlyCount(year: String, month: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.happicReportMonthlyURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = ["year": year, "month": month]
         
         let dataRequest = AF.request(url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: header)

--- a/Happic-iOS/Happic-iOS/Network/APIService/HaruHappicService/HaruHappicService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/HaruHappicService/HaruHappicService.swift
@@ -10,13 +10,14 @@ import Alamofire
 
 struct HaruHappicService {
     static let shared = HaruHappicService()
-    
+    private let userManager = UserManager.shared
+
     private init() {}
     
     /// 하루해픽 전체 조회
     func getHaruHappic(year: Int, month: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.haruHappicURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let parameters: Parameters = ["year": year, "month": month]
         
         let dataRequest = AF.request(url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: header)

--- a/Happic-iOS/Happic-iOS/Network/APIService/HomeService/HomeService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/HomeService/HomeService.swift
@@ -10,12 +10,13 @@ import Alamofire
 
 struct HomeService {
     static let shared = HomeService()
-    
+    private let userManager = UserManager.shared
+
     private init() {}
     
     func homeViewLoad(completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.homeURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         
         let dataRequest = AF.request(url, method: .get, encoding: URLEncoding.default, headers: header)
         
@@ -26,6 +27,7 @@ struct HomeService {
                 guard let value = response.value else { return }
                 
                 let networkResult = NetworkHelper.parseJSON(by: statusCode, data: value, type: HomeModel.self)
+                print(networkResult)
                 completion(networkResult)
             case .failure:
                 completion(.networkFail)
@@ -35,7 +37,7 @@ struct HomeService {
     
     func getHappicCapsule(completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.happicCapsuleURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         
         let dataRequest = AF.request(url, method: .get, encoding: URLEncoding.default, headers: header)
         

--- a/Happic-iOS/Happic-iOS/Network/APIService/HomeService/HomeService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/HomeService/HomeService.swift
@@ -27,7 +27,6 @@ struct HomeService {
                 guard let value = response.value else { return }
                 
                 let networkResult = NetworkHelper.parseJSON(by: statusCode, data: value, type: HomeModel.self)
-                print(networkResult)
                 completion(networkResult)
             case .failure:
                 completion(.networkFail)

--- a/Happic-iOS/Happic-iOS/Network/APIService/PushAlarmService/PushUserRegisterService.swift
+++ b/Happic-iOS/Happic-iOS/Network/APIService/PushAlarmService/PushUserRegisterService.swift
@@ -10,12 +10,13 @@ import Alamofire
 
 struct PushUserRegisterService {
     static let shared = PushUserRegisterService()
-    
+    private let userManager = UserManager.shared
+
     private init() {}
     
     func registerUserWithFcmToken(token: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         let url = APIConstants.pushUserRegisterURL
-        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + UserDefaults.tempJWT]
+        let header: HTTPHeaders = ["Content-Type": "application/json", "Authorization": "Bearer " + userManager.getJwtToken]
         let body: Parameters = [
             "fcmToken": token
         ]

--- a/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
@@ -41,11 +41,13 @@ class AuthViewController: UIViewController {
                     if let accessToken = oauthToken?.accessToken {
                         print("앱 로그인 성공" + accessToken)
     
-//                        self.kakaoLogin(token: accessToken)
-                        
-                        let createCharacterView = CreateCharacterViewController.instantiate()
-                        createCharacterView.accessToken = accessToken
-                        self.navigationController?.pushViewController(createCharacterView, animated: true)
+                        if AuthApi.hasToken() {
+                            self.kakaoLogin(token: accessToken)
+                        } else {
+                            let createCharacterView = CreateCharacterViewController.instantiate()
+                            createCharacterView.accessToken = accessToken
+                            self.navigationController?.pushViewController(createCharacterView, animated: true)
+                        }
                     }
                 }
             }
@@ -57,11 +59,13 @@ class AuthViewController: UIViewController {
                    if let accessToken = oauthToken?.accessToken {
                        print("웹 로그인 성공" + accessToken)
                        
-//                       self.kakaoLogin(token: accessToken)
-                       
-                       let createCharacterView = CreateCharacterViewController.instantiate()
-                       createCharacterView.accessToken = accessToken
-                       self.navigationController?.pushViewController(createCharacterView, animated: true)
+                       if AuthApi.hasToken() {
+                           self.kakaoLogin(token: accessToken)
+                       } else {
+                           let createCharacterView = CreateCharacterViewController.instantiate()
+                           createCharacterView.accessToken = accessToken
+                           self.navigationController?.pushViewController(createCharacterView, animated: true)
+                       }
                    }
                }
             }
@@ -77,8 +81,9 @@ extension AuthViewController {
             case .success(let result):
                 guard let data = result as? KakaoLoginModel else { return }
                 print("jwt 토큰 받기 성공", data)
-                let createCharacterView = CreateCharacterViewController.instantiate()
-                self.navigationController?.pushViewController(createCharacterView, animated: true)
+                let userManager = UserManager.shared
+                userManager.setSocialToken(token: data.jwtToken)
+                self.dismiss(animated: true)
             default:
                 print(response)
             }

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -117,7 +117,8 @@ extension CharacterNameViewController {
             case .success(let result):
                 guard let data = result as? SignUpModel else { return }
                 self.userManager.setSocialToken(token: data.jwtToken)
-                print("signup success", data)
+                
+                self.dismiss(animated: true)
             default:
                 print(response)
             }

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class CharacterNameViewController: UIViewController {
     
     var accessToken: String = ""
+    private let userManager = UserManager.shared
 
     @IBOutlet weak var characterImage: UIImageView!
     @IBAction func completeButtonDidTap(_ sender: Any) {
@@ -19,7 +20,7 @@ class CharacterNameViewController: UIViewController {
         
         if let name = characterNameTextField.text {
             signUp(characterId: flag, characterName: name, accessToken: accessToken)
-//            changeCharacter(characterId: flag, characterName: name)
+            changeCharacter(characterId: flag, characterName: name)
         }
         
         namingCharacterLabel.text = "당신의 \(userName) 이(가) 오고 있어요 \n 잠시 기다려주세요"
@@ -115,6 +116,7 @@ extension CharacterNameViewController {
             switch response {
             case .success(let result):
                 guard let data = result as? SignUpModel else { return }
+                self.userManager.setSocialToken(token: data.jwtToken)
                 print("signup success", data)
             default:
                 print(response)

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class CharacterNameViewController: UIViewController {
     
     var accessToken: String = ""
+    var isSignUp: Bool = true
     private let userManager = UserManager.shared
 
     @IBOutlet weak var characterImage: UIImageView!
@@ -19,7 +20,9 @@ class CharacterNameViewController: UIViewController {
         }
         
         if let name = characterNameTextField.text {
-            signUp(characterId: flag, characterName: name, accessToken: accessToken)
+            if isSignUp {
+                signUp(characterId: flag, characterName: name, accessToken: accessToken)
+            }
             changeCharacter(characterId: flag, characterName: name)
         }
         
@@ -33,7 +36,10 @@ class CharacterNameViewController: UIViewController {
         
         namingCharacterLabel.attributedText = attributedStr
         
-        self.dismiss(animated: true)
+        guard let pvc = self.presentingViewController else { return }
+        self.dismiss(animated: true) {
+            pvc.dismiss(animated: true)
+        }
     }
     
     @IBAction func backButtonDidTap(_ sender: Any) {

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -36,9 +36,9 @@ class CharacterNameViewController: UIViewController {
         
         namingCharacterLabel.attributedText = attributedStr
         
-        guard let pvc = self.presentingViewController else { return }
+        guard let previousViewController = self.presentingViewController else { return }
         self.dismiss(animated: true) {
-            pvc.dismiss(animated: true)
+            previousViewController.dismiss(animated: true)
         }
     }
     

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CreateCharacterViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CreateCharacterViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class CreateCharacterViewController: UIViewController, Storyboarded {
     
     var accessToken: String = ""
+    var isSignUp: Bool = true
 
     @IBOutlet weak var bottomViewHeight: NSLayoutConstraint!
     
@@ -116,6 +117,7 @@ extension CreateCharacterViewController: CharacterIntroduceViewDelegate {
         let characterNameStoryBoard = UIStoryboard(name: "CharacterNameView", bundle: nil)
         guard let characterNameViewController = characterNameStoryBoard.instantiateViewController(withIdentifier: "CharacterNameViewController") as? CharacterNameViewController else { return }
         characterNameViewController.flag = flag
+        characterNameViewController.isSignUp = isSignUp
         self.navigationController?.pushViewController(characterNameViewController, animated: true)
         characterNameViewController.accessToken = accessToken
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -35,8 +35,10 @@ final class HappicReportController: UIViewController {
         setPurpleBackgroundColor()
         configureUI()
         setDelegate()
-        
-        getHappicReportSummary(year: "2022", month: "7")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        getHappicReportSummary(year: "2022", month: currentMonth)
     }
     
     // MARK: - Functions

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicDetailController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicDetailController.swift
@@ -180,6 +180,7 @@ final class HaruHappicDetailController: UIViewController {
     
     @objc private func showAlertPopUp() {
         let alartPopUpView = CustomPopUpController()
+        alartPopUpView.delegate = self
         alartPopUpView.id = models[previousIndex].id
         alartPopUpView.setPopUpText(title: "해픽 삭제",
                                     contents: "사진 삭제시 사진과 태그가 모두 지워집니다.\n또한 해당 내용은 복구가 불가능합니다.\n삭제하시겠습니까?",
@@ -327,5 +328,12 @@ extension HaruHappicDetailController: UICollectionViewDelegateFlowLayout {
                 zoomCell.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
             },
             completion: nil)
+    }
+}
+
+extension HaruHappicDetailController: CustomPopUpControllerDelegate {
+    func popUpDidDismiss() {
+        navigationController?.popViewController(animated: true)
+        showToast(message: "게시글이 삭제되었습니다.")
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 final class HomeController: BaseUploadViewController {
     
+    // MARK: - Properties
+    let userManager = UserManager.shared
+    
     // MARK: - UI
     private lazy var levelLabel = UILabel().then {
         $0.text = "Lv1. 응애입니다."
@@ -74,14 +77,10 @@ final class HomeController: BaseUploadViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        checkLogin()
         homeViewLoad()
         setPurpleBackgroundColor()
         configureUI()
-        let nextSB = UIStoryboard(name: "AuthView", bundle: nil)
-        let nextVC = nextSB.instantiateViewController(withIdentifier: "AuthViewController")
-        let nav = UINavigationController(rootViewController: nextVC)
-        nav.modalPresentationStyle = .fullScreen
-        self.present(nav, animated: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -138,6 +137,16 @@ final class HomeController: BaseUploadViewController {
     @objc private func handleActionButtonDidTap(sender: UIButton) {
 //        checkPostStatus()
         setActionSheet()
+    }
+    
+    func checkLogin() {
+        if !userManager.hasJwtToken {
+            let nextSB = UIStoryboard(name: "AuthView", bundle: nil)
+            let nextVC = nextSB.instantiateViewController(withIdentifier: "AuthViewController")
+            let nav = UINavigationController(rootViewController: nextVC)
+            nav.modalPresentationStyle = .fullScreen
+            self.present(nav, animated: false)
+        }
     }
 }
 


### PR DESCRIPTION
## 💥 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- closed: #203 

## 💥 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- jwt 토큰을 UserDefault에 저장
- 자동 로그인 구현
- 로그인 플로우 수정
- 캐릭터 변경 기능 추가 (설정 뷰에서)
- 게시글 삭제 후 하루 해픽 뷰로 돌아가도록 수정
- 해픽 레포트의 API 호출 시점 viewWillAppear로 수정

## 💥 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- pull 받고 시뮬에서 앱 삭제했다가 다시 실행해보실래요? 이미 회원가입을 한 카카오 계정이라면 회원가입 대신 로그인 뷰가 보여야합니다.

## 💥 참고 사항

<!-- 참고할 사항(+스크린샷, ToDo)이 있다면 적어주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2022-07-27 at 15 47 51](https://user-images.githubusercontent.com/77267404/181180235-459910aa-ef35-4222-9b37-927c74139b16.gif)

