### PR TITLE
[Feat] 네트워크 오류시 띄우는 얼럿 뷰 추가 및 홈 컨트롤러 levelProgressView 이슈 (#210)

### DIFF
--- a/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
+++ b/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
@@ -44,7 +44,7 @@ extension UIViewController {
                               endPoint: CGPoint(x: 2.4, y: 0.4))
     }
     
-    func makeAlert(title: String, message: String? = nil,
+    func showAlert(title: String, message: String? = nil,
                    okTitle: String = "확인", okAction: ((UIAlertAction) -> Void)? = nil,
                    completion : (() -> Void)? = nil) {
         LoadingIndicator.hideLoading()

--- a/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
+++ b/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
@@ -47,6 +47,7 @@ extension UIViewController {
     func makeAlert(title: String, message: String? = nil,
                    okTitle: String = "확인", okAction: ((UIAlertAction) -> Void)? = nil,
                    completion : (() -> Void)? = nil) {
+        LoadingIndicator.hideLoading()
         let generator = UIImpactFeedbackGenerator(style: .medium)
         generator.impactOccurred()
         let alertVC = UIAlertController(title: title, message: message,

--- a/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
+++ b/Happic-iOS/Happic-iOS/Global/Extension/UIViewController+.swift
@@ -44,4 +44,15 @@ extension UIViewController {
                               endPoint: CGPoint(x: 2.4, y: 0.4))
     }
     
+    func makeAlert(title: String, message: String? = nil,
+                   okTitle: String = "확인", okAction: ((UIAlertAction) -> Void)? = nil,
+                   completion : (() -> Void)? = nil) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        let alertVC = UIAlertController(title: title, message: message,
+                                                    preferredStyle: .alert)
+        let okAction = UIAlertAction(title: okTitle, style: .default, handler: okAction)
+        alertVC.addAction(okAction)
+        self.present(alertVC, animated: true, completion: completion)
+    }
 }

--- a/Happic-iOS/Happic-iOS/Global/Util/LoadingIndicator.swift
+++ b/Happic-iOS/Happic-iOS/Global/Util/LoadingIndicator.swift
@@ -14,11 +14,10 @@ class LoadingIndicator {
             guard let window = UIApplication.shared.windows.last else { return }
 
             let loadingIndicatorView: UIActivityIndicatorView
-            if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView } ) as? UIActivityIndicatorView {
+            if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView }) as? UIActivityIndicatorView {
                 loadingIndicatorView = existedView
             } else {
                 loadingIndicatorView = UIActivityIndicatorView(style: .large)
-                /// 다른 UI가 눌리지 않도록 indicatorView의 크기를 full로 할당
                 loadingIndicatorView.frame = window.frame
                 loadingIndicatorView.color = .lightGray
                 window.addSubview(loadingIndicatorView)

--- a/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
@@ -86,7 +86,7 @@ extension AuthViewController {
                 LoadingIndicator.hideLoading()
                 self.dismiss(animated: true)
             default:
-                LoadingIndicator.hideLoading()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }

--- a/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Auth/Controller/AuthViewController.swift
@@ -86,7 +86,7 @@ extension AuthViewController {
                 LoadingIndicator.hideLoading()
                 self.dismiss(animated: true)
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -128,7 +128,7 @@ extension CharacterNameViewController {
                 LoadingIndicator.hideLoading()
                 self.dismiss(animated: true)
             default:
-                LoadingIndicator.hideLoading()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }
@@ -139,11 +139,12 @@ extension CharacterNameViewController {
         SignUpService.shared.changeCharacter(characterId: characterId, characterName: characterName) { response in
             switch response {
             case .success:
+                LoadingIndicator.hideLoading()
                 print("change character name success")
             default:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateCharacter/Controller/CharacterNameViewController.swift
@@ -128,7 +128,7 @@ extension CharacterNameViewController {
                 LoadingIndicator.hideLoading()
                 self.dismiss(animated: true)
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }
@@ -142,7 +142,7 @@ extension CharacterNameViewController {
                 LoadingIndicator.hideLoading()
                 print("change character name success")
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }

--- a/Happic-iOS/Happic-iOS/Screens/CreateContents/Controller/CreateContentsController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateContents/Controller/CreateContentsController.swift
@@ -354,7 +354,7 @@ extension CreateContentsController {
                 self.photoURL = data.link
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }
@@ -371,7 +371,7 @@ extension CreateContentsController {
                 self.whatTagView.setData(tags: data.what)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -402,7 +402,7 @@ extension CreateContentsController {
             default:
                 self.dismissViewController()
                 self.delegate?.showToastAfterCreating("\(response)")
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/CreateContents/Controller/CreateContentsController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/CreateContents/Controller/CreateContentsController.swift
@@ -352,11 +352,12 @@ extension CreateContentsController {
                 print(response)
                 guard let data = result as? UploadImageModel else { return }
                 self.photoURL = data.link
+                LoadingIndicator.hideLoading()
             default:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 print(response)
             }
         }
-        LoadingIndicator.hideLoading()
     }
     
     func getRecommendTag() {
@@ -368,11 +369,11 @@ extension CreateContentsController {
                 self.whereTagView.setData(tags: data.place)
                 self.whoTagView.setData(tags: data.who)
                 self.whatTagView.setData(tags: data.what)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
     
     func createHaruHappic() {
@@ -397,11 +398,12 @@ extension CreateContentsController {
             case .success:
                 self.dismissViewController()
                 self.delegate?.showToastAfterCreating("오늘의 해픽을 등록했어요")
+                LoadingIndicator.hideLoading()
             default:
                 self.dismissViewController()
                 self.delegate?.showToastAfterCreating("\(response)")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicCapsule/Controller/HappicCapsuleController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicCapsule/Controller/HappicCapsuleController.swift
@@ -152,11 +152,11 @@ extension HappicCapsuleController {
                 self.capsuleView.whoLabel.text = "#\(data.who)"
                 self.capsuleView.whatLabel.text = "#\(data.what)"
                 self.capsuleView.whereLabel.text = "#\(data.place)"
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
     
     func canPost() {
@@ -166,10 +166,10 @@ extension HappicCapsuleController {
             case .success(let result):
                 guard let data = result as? PostStatusModel else { return }
                 self.createContentsButton.isHidden = data.isPosted
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicCapsule/Controller/HappicCapsuleController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicCapsule/Controller/HappicCapsuleController.swift
@@ -154,7 +154,7 @@ extension HappicCapsuleController {
                 self.capsuleView.whereLabel.text = "#\(data.place)"
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -168,7 +168,7 @@ extension HappicCapsuleController {
                 self.createContentsButton.isHidden = data.isPosted
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -188,10 +188,10 @@ extension HappicReportController {
                 self.keywordRankView.setData(model: data.rank2S)
                 self.categoryRankView.setData(model: data.rank3S)
                 self.monthHappicRecordView.setData(model: data.rank4S)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -190,7 +190,7 @@ extension HappicReportController {
                 self.monthHappicRecordView.setData(model: data.rank4S)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -77,8 +77,9 @@ extension CategoryRankController {
                 guard let data = result as? [KeywordModel] else { return }
                 self.handleEmptyView(isEmpty: data.isEmpty)
                 self.categoryRankView.setWhenData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -87,8 +88,9 @@ extension CategoryRankController {
             case .success(let result):
                 guard let data = result as? [KeywordModel] else { return }
                 self.categoryRankView.setWhereData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -97,8 +99,9 @@ extension CategoryRankController {
             case .success(let result):
                 guard let data = result as? [KeywordModel] else { return }
                 self.categoryRankView.setWhoData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -107,10 +110,10 @@ extension CategoryRankController {
             case .success(let result):
                 guard let data = result as? [KeywordModel] else { return }
                 self.categoryRankView.setWhatData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/CategoryRankController.swift
@@ -79,7 +79,7 @@ extension CategoryRankController {
                 self.categoryRankView.setWhenData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -90,7 +90,7 @@ extension CategoryRankController {
                 self.categoryRankView.setWhereData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -101,7 +101,7 @@ extension CategoryRankController {
                 self.categoryRankView.setWhoData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
         
@@ -112,7 +112,7 @@ extension CategoryRankController {
                 self.categoryRankView.setWhatData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
@@ -76,10 +76,10 @@ extension KeywordRankController {
                 self.keywordRankView.isHidden = data.isEmpty
                 self.containerView.isHidden = !data.isEmpty
                 self.keywordRankView.setData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/KeywordRankController.swift
@@ -78,7 +78,7 @@ extension KeywordRankController {
                 self.keywordRankView.setData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -82,7 +82,7 @@ extension MonthHappicRecordController {
                 self.calendarView.setData(model: data)
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/OverallStats/StatsController/MonthHappicRecordController.swift
@@ -80,10 +80,10 @@ extension MonthHappicRecordController {
                 guard let data = result as? MonthlyCountModel else { return }
                 self.monthHappicRecordView.setData(model: data)
                 self.calendarView.setData(model: data)
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
@@ -99,11 +99,11 @@ extension HaruHappicController {
                 } else {
                     self.setActionSheet()
                 }
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }
 

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
@@ -101,7 +101,7 @@ extension HaruHappicController {
                 }
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
@@ -165,7 +165,7 @@ extension HomeController {
                 }
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -219,7 +219,7 @@ extension HomeController {
                 
                 LoadingIndicator.hideLoading()
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
@@ -163,11 +163,11 @@ extension HomeController {
                 } else {
                     self.setActionSheet()
                 }
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }
 
@@ -215,10 +215,11 @@ extension HomeController {
                 self.progressLabel.text = "\(data.growthRate)/6"
                 self.nameLabel.text = data.characterName
                 self.levelProgressView.progress = Float(data.growthRate / 6)
+                
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Home/Controller/HomeController.swift
@@ -214,7 +214,8 @@ extension HomeController {
                 }
                 self.progressLabel.text = "\(data.growthRate)/6"
                 self.nameLabel.text = data.characterName
-                self.levelProgressView.progress = Float(data.growthRate / 6)
+                let progressValue: Float = Float(data.growthRate) / 6
+                self.levelProgressView.setProgress(progressValue, animated: true)
                 
                 LoadingIndicator.hideLoading()
             default:


### PR DESCRIPTION
## 💥 관련 이슈

- closed: #210 

## 💥 구현/변경 사항 및 이유

- 네트워크 오류시 띄우는 얼럿 뷰 추가 및 뷰 연결
- levelProgressView가 제대로 채워지지 않는 이슈 해결


## 💥 참고 사항

| 얼럿 뷰 예시 | 프로그레스 뷰 이슈 해결 |
| :---: | :---: |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-07-28 at 13 57 19](https://user-images.githubusercontent.com/80062632/181425136-4fa30fe9-87f7-4f48-aabe-16c830bb48a4.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-07-28 at 14 07 56](https://user-images.githubusercontent.com/80062632/181425162-7bd7cdac-184b-4062-903d-e559782ae6ee.png) |