### PR TITLE
[Fix] 하루해픽 empty 태그 뷰가 첫 로딩 시 보이지 않는 이슈 (#209)

### DIFF
--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
@@ -121,8 +121,9 @@ extension HaruHappicController {
                 } else {
                     self.haruHappicPhotoController.setEmptyImageView(bool: false)
                     self.haruHappicTagController.setEmptyImageView(bool: false)
-                    self.haruHappicPhotoController.setData(models: self.models)
-                    self.haruHappicTagController.setData(models: self.models)
+                }
+                self.haruHappicPhotoController.setData(models: self.models)
+                self.haruHappicTagController.setData(models: self.models)
                 LoadingIndicator.hideLoading()
             default:
                 self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicController.swift
@@ -123,11 +123,10 @@ extension HaruHappicController {
                     self.haruHappicTagController.setEmptyImageView(bool: false)
                     self.haruHappicPhotoController.setData(models: self.models)
                     self.haruHappicTagController.setData(models: self.models)
-                }
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
-        LoadingIndicator.hideLoading()
     }
 }

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicPhotoController.swift
@@ -74,7 +74,6 @@ final class HaruHappicPhotoController: UIViewController {
         }
         
         customMonthPickerView.isHidden = true
-        emptyImageView.isHidden = true
     }
     
     private func setDelegate() {

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/View/HaruHappicTagController.swift
@@ -75,7 +75,6 @@ final class HaruHappicTagController: UIViewController {
         }
         
         customMonthPickerView.isHidden = true
-        emptyImageView.isHidden = true
     }
     
     private func setDelegate() {


### PR DESCRIPTION
## 💥 관련 이슈

- closed: #209 

## 💥 구현/변경 사항 및 이유

- 하루해픽 empty 태그 뷰가 첫 로딩 시 보이지 않는 이슈 

## 💥 참고 사항

![Simulator Screen Recording - iPhone 13 mini - 2022-07-29 at 00 02 10](https://user-images.githubusercontent.com/80062632/181571569-87cef858-565e-42f5-8b1d-40e7bbbc2197.gif)
