### PR TITLE
[Chore] Custom Month View 현재 달 수정 (#214)

### DIFF
--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomMonthView.swift
@@ -16,11 +16,16 @@ final class CustomMonthView: UIView {
     
     // MARK: - Properties
     weak var delegate: CustomMonthViewDelegate?
+    var currentMonth: Int = Calendar.current.component(.month, from: Date())
     var isMonthViewEnabled: Bool = false
     
     // MARK: - UI
     lazy var monthLabel = UILabel().then {
-        $0.text = "2022 . 07"
+        if currentMonth < 10 {
+            $0.text = "2022 . 0" + "\(currentMonth)"
+        } else {
+            $0.text = "2022 . " + "\(currentMonth)"
+        }
         $0.textColor = .hpWhite
         $0.font = UIFont.font(.gmarketSansBold, ofSize: 16)
     }

--- a/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
+++ b/Happic-iOS/Happic-iOS/Global/UIComponent/CustomPopUpController.swift
@@ -152,10 +152,11 @@ extension CustomPopUpController {
             switch response {
             case .success:
                 self.dismiss(animated: true) {
+                    LoadingIndicator.hideLoading()
                     self.delegate?.popUpDidDismiss()
                 }
             default:
-                break
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HappicReport/Controller/HappicReportController.swift
@@ -11,7 +11,7 @@ import Then
 
 final class HappicReportController: UIViewController {
     // MARK: - Properties
-    var currentMonth: String = "7" {
+    var currentMonth: String = String(Calendar.current.component(.month, from: Date())) {
         didSet {
             setCustomMonthViewText(month: currentMonth)
             setCustomMonthPickerViewSelected(month: currentMonth)

--- a/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicDetailController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/HaruHappic/Controller/HaruHappicDetailController.swift
@@ -52,7 +52,6 @@ final class HaruHappicDetailController: UIViewController {
     }
     
     private lazy var dateLabel = UILabel().then {
-        $0.text = "2022 . 07 . 20"
         $0.textColor = .hpWhite
         $0.font = UIFont.font(.pretendardBold, ofSize: 18)
     }
@@ -68,21 +67,10 @@ final class HaruHappicDetailController: UIViewController {
         return collectionView
     }()
     
-    private lazy var whenLabel = UILabel().then {
-        $0.text = "#오후2시"
-    }
-    
-    private lazy var whereLabel = UILabel().then {
-        $0.text = "#집구석구석"
-    }
-    
-    private lazy var whoLabel = UILabel().then {
-        $0.text = "#햄식달식이"
-    }
-    
-    private lazy var whatLabel = UILabel().then {
-        $0.text = "#짱짱귀여워"
-    }
+    private lazy var whenLabel = UILabel()
+    private lazy var whereLabel = UILabel()
+    private lazy var whoLabel = UILabel()
+    private lazy var whatLabel = UILabel()
     
     private lazy var tagStackView = UIStackView(arrangedSubviews: [whenLabel, whereLabel, whoLabel, whatLabel]).then {
         $0.axis = .horizontal

--- a/Happic-iOS/Happic-iOS/Screens/Tabbar/Controller/TabBarController.swift
+++ b/Happic-iOS/Happic-iOS/Screens/Tabbar/Controller/TabBarController.swift
@@ -149,8 +149,9 @@ extension TabBarController {
                 } else {
                     self.setActionSheet()
                 }
+                LoadingIndicator.hideLoading()
             default:
-                break
+                self.showAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }


### PR DESCRIPTION
## 💥 관련 이슈

- closed: #214 

## 💥 구현/변경 사항 및 이유

- 하루해픽, 해픽레포트에서 사용하는 Custom Month View의  현재 달을 시스템에서 자동으로 받아오도록 수정했습니다.
- 이외 자잘한 코드 수정

## 💥 참고 사항

| 하루해픽 사진 뷰 | 하루해픽 태그 뷰 | 해픽레포트 뷰  | 
| :---: | :---: | :---: |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-08-01 at 14 51 51](https://user-images.githubusercontent.com/80062632/182081093-db20db14-d2fe-4601-8199-7a403e03f787.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-08-01 at 14 49 55](https://user-images.githubusercontent.com/80062632/182081037-0f183fd7-c3b9-4bb1-b531-c9dc5863a7b9.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-08-01 at 14 49 48](https://user-images.githubusercontent.com/80062632/182081003-6a55ff6c-2df9-4ec2-b93e-f4c181bacdbe.png) |